### PR TITLE
Bugfix: Página de observação com erro de parâmetro #2

### DIFF
--- a/membro/urls.py
+++ b/membro/urls.py
@@ -5,7 +5,7 @@ urlpatterns = patterns('membro.views',
                        (r'controle$', 'controle'),
                        (r'mensal/(?P<ano>\d+)/(?P<mes>\d+)$', 'mensal'),
                        (r'detalhes$', 'detalhes'),
-                       (r'obs/(?P<id>\d+)$', 'observacao'),
+                       (r'obs/(?P<controle_id>\d+)$', 'observacao'),
                        (r'mensalf$', 'mensal_func'),
                        (r'logs$', 'uso_admin'),
 

--- a/membro/views.py
+++ b/membro/views.py
@@ -65,7 +65,7 @@ def controle(request):
         controle.saida = datetime.now()
     controle.save()
     messages.info(request, u'Sua %s foi registrada com sucesso.' % acao)
-    return HttpResponseRedirect(reverse('membro.views.observacao', kwargs={'id': controle.id}))
+    return HttpResponseRedirect(reverse('membro.views.observacao', kwargs={'controle_id': controle.id}))
 
 
 @login_required


### PR DESCRIPTION
Corrigido o parametro enviado pelo urls e o reverse utilizado no views
para redirecionar o response ao salvar a saida/entrada do controle de
horas
