### PR TITLE
Corrigidos problemas com timezones em testes em #8.

### DIFF
--- a/membro/tests.py
+++ b/membro/tests.py
@@ -16,6 +16,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# Get current timezone
+tz = timezone.get_current_timezone()
+
+
 class TipoAssinaturaTest(TestCase):
     def test_unicode(self):
         ta = TipoAssinatura.objects.create(nome='Cheque')
@@ -145,10 +149,8 @@ class MembroControleTest(TestCase):
         membro = Membro.objects.create(id=1, nome='teste', site=True)
 
         Controle.objects.create(id=1, membro=membro,
-                                entrada=datetime(year=2000, month=01, day=01, hour=12,
-                                                 tzinfo=timezone.get_current_timezone()),
-                                saida=datetime(year=2000, month=01, day=01, hour=18, minute=30,
-                                               tzinfo=timezone.get_current_timezone()),
+                                entrada=tz.localize(datetime(year=2000, month=01, day=01, hour=12)),
+                                saida=tz.localize(datetime(year=2000, month=01, day=01, hour=18, minute=30)),
                                 almoco_devido=False, almoco=60)
         Controle.objects.get(id=1)
 
@@ -160,10 +162,10 @@ class MembroControleTest(TestCase):
         controle.save()
 
         controle = Controle.objects.get(pk=1)
-        entrada = datetime(year=2000, month=01, day=01, hour=12, minute=20, tzinfo=timezone.get_current_timezone())
+        entrada = tz.localize(datetime(year=2000, month=01, day=01, hour=12, minute=20))
         self.assertEquals(controle.entrada, entrada)
 
-        saida = datetime(year=2000, month=01, day=01, hour=18, minute=50, tzinfo=timezone.get_current_timezone())
+        saida = tz.localize(datetime(year=2000, month=01, day=01, hour=18, minute=50))
         self.assertEquals(controle.saida, saida)
 
 

--- a/protocolo/tests.py
+++ b/protocolo/tests.py
@@ -17,6 +17,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# Get current timezone
+tz = timezone.get_current_timezone()
+
+
 # Testes do arquivo com funções localizado em protocolo.templatetags.proto_tags que é utilizado nos templates HTML
 class PrototagTest(TestCase):
     def test_moeda_real(self):
@@ -91,8 +95,7 @@ class ProtocoloTest(TestCase):
         protocoloEstado = ProtocoloEstado.objects.create(nome='Pendente')
 
         p = Protocolo.objects.create(termo=t, tipo_documento=td, num_documento=2008, estado=protocoloEstado,
-                                     identificacao=iden,
-                                     data_chegada=datetime(2008, 9, 30, 10, 10, tzinfo=timezone.get_current_timezone()),
+                                     identificacao=iden, data_chegada=tz.localize(datetime(2008, 9, 30, 10, 10)),
                                      data_validade=datetime(2009, 8, 25), data_vencimento=datetime(2008, 9, 30),
                                      descricao="Conta mensal", origem=og, valor_total=None, descricao2=desc,
                                      moeda_estrangeira=False)
@@ -173,9 +176,9 @@ class ItemProtocoloTest(TestCase):
         desc = Descricao.objects.create(descricao='Descricao', entidade=ent)
 
         p = Protocolo.objects.create(termo=t, tipo_documento=td, num_documento=2008, estado=e, identificacao=iden,
-                                     data_chegada=datetime(2008, 9, 30, 10, 10), data_validade=date(2009, 8, 25),
-                                     data_vencimento=date(2008, 9, 30), descricao="Aditivo Uniemp", origem=og,
-                                     valor_total=None, descricao2=desc, moeda_estrangeira=False)
+                                     data_chegada=tz.localize(datetime(2008, 9, 30, 10, 10)), descricao2=desc,
+                                     data_validade=date(2009, 8, 25),data_vencimento=date(2008, 9, 30), origem=og,
+                                     valor_total=None, descricao="Aditivo Uniemp", moeda_estrangeira=False)
 
         ip = ItemProtocolo.objects.create(protocolo=p, descricao='Servico de conexao', quantidade=1,  # @UnusedVariable
                                           valor_unitario='59613.59')
@@ -262,9 +265,9 @@ class CotacaoTest(TestCase):
         iden = Identificacao.objects.create(contato=c, funcao='Tecnico', area='', ativo=True, endereco=endereco)
 
         cot = Cotacao.objects.create(termo=t, tipo_documento=td, estado=e, identificacao=iden,  # @UnusedVariable
-                                     data_chegada=datetime(2008, 12, 12, 9, 10), data_validade=date(2009, 12, 13),
-                                     descricao='Compra de Aparelhos', origem=og, parecer='custo alto', aceito=False,
-                                     entrega='confirmada', moeda_estrangeira=False)
+                                     data_chegada=tz.localize(datetime(2008, 12, 12, 9, 10)),
+                                     data_validade=date(2009, 12, 13), origem=og, parecer='custo alto', aceito=False,
+                                     descricao='Compra de Aparelhos', entrega='confirmada', moeda_estrangeira=False)
 
     def test_unicode(self):
         cot = Cotacao.objects.get(pk=1)


### PR DESCRIPTION
Quando é criado um `datetime` passando o parâmetro `tzinfo`, é utilizado
um timezone LMT, o que causa discrepâncias com os timezones oficiais.
Para resolver isso, utiliza-se o método `localize` to timezone.
