### PR TITLE
Corrige #21: Formatação de data e hora corrigida.

### DIFF
--- a/configuracao/static/css/forms.css
+++ b/configuracao/static/css/forms.css
@@ -1,4 +1,4 @@
-@import url('widgets.css');
+@import url('../admin/css/widgets.css');
 
 /* FORM ROWS */
 

--- a/configuracao/templates/admin/base.html
+++ b/configuracao/templates/admin/base.html
@@ -118,7 +118,8 @@ $(document).ajaxSend(function(event, xhr, settings) {
 </head>
 {% load i18n %}
 
-<body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}">
+<body class="{% if is_popup %}popup {% endif %}{% block bodyclass %}{% endblock %}"
+  data-admin-utc-offset="{% now "Z" %}">
 {% block header %}
         <!-- Header -->
     {% if not is_popup %}

--- a/identificacao/models.py
+++ b/identificacao/models.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.db import models
+from django.utils import timezone
 from utils.models import CNPJField
 from django.utils.translation import ugettext_lazy as _
 from datetime import datetime
@@ -296,6 +297,7 @@ class Identificacao(models.Model):
 
     # Retorna o histórico formatado.
     def formata_historico(self):
+        historico = timezone.localtime(self.historico) if timezone.is_aware(self.historico) else historico
         return self.historico.strftime('%d/%m/%y %H:%M')
     formata_historico.short_description = _(u'Histórico')
 

--- a/membro/admin.py
+++ b/membro/admin.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.contrib import admin
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from membro.forms import MembroAdminForm, ControleFeriasAdminForm,\
     ControleFeriasAdminFormSet, DispensaLegalAdminForms, ControleAdminForms
@@ -206,13 +207,21 @@ class ControleAdmin(admin.ModelAdmin):
 
     def format_entrada(self, obj):
         if obj.entrada:
-            return obj.entrada.strftime('%d %b %Y - %H:%M')
+            if timezone.is_aware(obj.entrada):
+                entrada = timezone.localtime(obj.entrada)
+            else:
+                entrada = obj.entrada
+            return entrada.strftime('%d %b %Y - %H:%M')
         return '(Nenhum)'
     format_entrada.short_description = 'Entrada'
 
     def format_saida(self, obj):
         if obj.saida:
-            return obj.saida.strftime('%d %b %Y - %H:%M')
+            if timezone.is_aware(obj.saida):
+                saida = timezone.localtime(obj.saida)
+            else:
+                saida = obj.saida
+            return saida.strftime('%d %b %Y - %H:%M')
         return '(Nenhum)'
     format_saida.short_description = 'Saída'
 

--- a/membro/models.py
+++ b/membro/models.py
@@ -6,6 +6,7 @@
 from datetime import timedelta, datetime, date
 from django.db import models
 from django.db.models import Q
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from django.utils.functional import cached_property
 from django.core.urlresolvers import reverse
@@ -562,10 +563,12 @@ class Controle(models.Model):
     almoco = models.IntegerField(_(u'Tempo de almoço em minutos'), null=True, blank=True, default=60)
 
     def __unicode__(self):
+        entrada = timezone.localtime(self.entrada) if timezone.is_aware(self.entrada) else self.entrada
         if self.saida:
-            return u'%s - de %s a %s' % (self.membro, self.entrada, self.saida)
+            saida = timezone.localtime(self.saida) if timezone.is_aware(self.saida) else self.saida
+            return u'%s - de %s a %s' % (self.membro, entrada, saida)
         else:
-            return u'%s - %s' % (self.membro, self.entrada)
+            return u'%s - %s' % (self.membro, entrada)
 
     @cached_property
     def segundos(self):

--- a/membro/tests.py
+++ b/membro/tests.py
@@ -171,6 +171,16 @@ class MembroControleTest(TestCase):
         saida = tz.localize(datetime(year=2000, month=01, day=01, hour=18, minute=50))
         self.assertEquals(controle.saida, saida)
 
+    def test_controle_unicode(self):
+        membro = Membro.objects.create(id=1, nome='teste', site=True)
+
+        Controle.objects.create(id=1, membro=membro,
+                                entrada=tz.localize(datetime(year=2000, month=01, day=01, hour=12)),
+                                saida=tz.localize(datetime(year=2000, month=01, day=01, hour=18, minute=30)),
+                                almoco_devido=False, almoco=60)
+        controle = Controle.objects.get(id=1)
+
+        self.assertEqual(controle.__unicode__(), 'teste - de 2000-01-01 12:00:00-02:00 a 2000-01-01 18:30:00-02:00')
 
 class MembroControleHorarioTest(TestCase):
 

--- a/rede/models.py
+++ b/rede/models.py
@@ -6,6 +6,7 @@
 from django.db import models
 from django.core.validators import MinValueValidator, MaxValueValidator
 from decimal import Decimal
+from django.utils import timezone
 from ipaddress import IPv4Address, IPv6Address
 from django.utils.translation import ugettext_lazy as _
 
@@ -122,7 +123,7 @@ class Historico(models.Model):
     equipamento = models.ForeignKey('patrimonio.Patrimonio', null=True, blank=True)
 
     def __unicode__(self):
-        return self.horario
+        return timezone.localtime(self.horario) if timezone.is_aware(self.horario) else self.horario
 
 
 UNIDADES = (


### PR DESCRIPTION
Métodos que formatam data e hora foram modificados para primeiro
converter a data/hora obtida do banco de dados para o timezone
local.
Template base.html corrigido para que o teste de hora do servidor
versus hora do cliente funcione.
Widgets.css certo incluído em forms.css para carregar as imagens
do calendário e relógio.
